### PR TITLE
Use `ping` command with either `-4` or `-6` flag

### DIFF
--- a/pmtu
+++ b/pmtu
@@ -12,7 +12,8 @@ def ping_works(payload_size, args):
         # we capture the output to prevent ping
         # from printing to terminal
         _output = subprocess.check_output([
-            'ping' if args.ipv4 else 'ping6',
+            'ping',
+            '-4' if args.ipv4 else '-6',
             '-M', 'do',
             '-c', '1',
             '-w', str(args.step_timeout_sec),


### PR DESCRIPTION
Just stumbled upon your script today. Exactly what I needed :)
I had to modify it a bit to work with some more modern distros.

The current iputils do no longer provide a binary called `ping6`. They
integrated the functionality into `ping`. By using the `-6` parameter it
can be switched into explicit IPv6 mode.